### PR TITLE
Fix 15693 byte order

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -130,7 +130,10 @@ void detect_card()
             break;
         case NFC_CARD_VICINITY:
             hid_cardio.current[0] = REPORT_ID_EAMU;
-            memcpy(hid_cardio.current + 1, card.uid, 8);
+            // 15693 cards store uid in reverse byte order
+            for (int i = 0; i < 8; i++) {
+                hid_cardio.current[i + 1] = card.uid[7 - i];
+            }
             break;
         default:
             memset(hid_cardio.current, 0, 9);


### PR DESCRIPTION
15693 cards store uid in reverse byte order, ending with 04E0, but games will only card in if cardio reports a uid starting with E004. This PR reverses the order of the bytes that cardio reports. Only tested with a PN5180, but my understanding is that a PN532 should never hit this point.